### PR TITLE
Interview Task: Split 'Addons' and 'Views' pages

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -6,8 +6,14 @@
           <f7-navbar title="Navigation"></f7-navbar>
           <f7-list>
             <f7-list-item
-              link="/"
+              link="/addons/"
               title="Addons"
+              reload-all
+              panel-close
+            ></f7-list-item>
+            <f7-list-item
+              link="/views/"
+              title="Views"
               reload-all
               panel-close
             ></f7-list-item>

--- a/src/pages/addons.vue
+++ b/src/pages/addons.vue
@@ -1,0 +1,29 @@
+<template>
+  <f7-page>
+    <f7-navbar>
+      <tommy-nav-menu></tommy-nav-menu>
+      <f7-nav-title>Addons</f7-nav-title>
+      <f7-nav-right>
+        <f7-link href="/settings/" icon-material="settings"></f7-link>
+      </f7-nav-right>
+    </f7-navbar>
+
+    <!-- Main addons list -->
+    <f7-block-title>Addons</f7-block-title>
+    <f7-list media-list>
+      <f7-list-item
+        v-for="(addon, index) in $root.addons"
+        :key="index"
+        :link="`/addon-details/${addon.package}/`"
+        :title="addon.title"
+        :after="addon.version"
+        :text="addon.summary"
+      >
+        <img slot="media" class="icon" width="80" :src="addon.icon_url" />
+      </f7-list-item>
+    </f7-list>
+  </f7-page>
+</template>
+<script>
+  export default {};
+</script>

--- a/src/pages/views.vue
+++ b/src/pages/views.vue
@@ -2,26 +2,11 @@
   <f7-page>
     <f7-navbar>
       <tommy-nav-menu></tommy-nav-menu>
-      <f7-nav-title>Home</f7-nav-title>
+      <f7-nav-title>Views</f7-nav-title>
       <f7-nav-right>
         <f7-link href="/settings/" icon-material="settings"></f7-link>
       </f7-nav-right>
     </f7-navbar>
-
-    <!-- Main addons list -->
-    <f7-block-title>Addons</f7-block-title>
-    <f7-list media-list>
-      <f7-list-item
-        v-for="(addon, index) in $root.addons"
-        :key="index"
-        :link="`/addon-details/${addon.package}/`"
-        :title="addon.title"
-        :after="addon.version"
-        :text="addon.summary"
-      >
-        <img slot="media" class="icon" width="80" :src="addon.icon_url" />
-      </f7-list-item>
-    </f7-list>
 
     <!-- Main addons views list -->
     <f7-block-title>Views</f7-block-title>
@@ -38,16 +23,9 @@
     </f7-list>
   </f7-page>
 </template>
-
 <script>
-  // Import config if dynamic re-routing needed from `mounted()`
-  // import config from "../../config.json";
-
   export default {
     mounted() {
-      // Alternative implementation of default 'starting_page'
-      // by re-routing to desired starting_page.
-      // this.$f7router.navigate({ name: config.starting_page })
     },
     methods: {
       addonUrl(addon) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,23 +1,43 @@
-import Home from './pages/home.vue';
+// import Home from './pages/home.vue';     // <== Can be removed pending PR review
+import coreRoutes from 'tommy-core/src/routes';
 import Settings from './pages/settings.vue';
 import AddonDetails from './pages/addon-details.vue';
+import Addons from './pages/addons.vue';
 
-import coreRoutes from 'tommy-core/src/routes';
+import Views from './pages/views.vue';
+import config from '../config.json';
+
+let StartPage = undefined;
+if (config.starting_page) {
+  StartPage = () => import('./pages/' + config.starting_page + '.vue');
+} else {
+  StartPage = () => import('./pages/home.vue');
+}
 
 const routes = [
   {
     path: '/',
-    component: Home,
+    component: StartPage,
   },
   {
     path: '/settings/',
     component: Settings,
   },
   {
+    path: '/addons/',
+    component: Addons,
+    name: 'addons',
+  },
+  {
+    path: '/Views/',
+    component: Views,
+    name: 'views',
+  },
+  {
     path: '/addon-details/:package/',
     component: AddonDetails,
   },
-  ...coreRoutes
+  ...coreRoutes,
 ];
 
 export default routes;


### PR DESCRIPTION
Modified app as follows:

- Split `Addons` and `Views` into separate pages

- Added links to these pages into side navigation in `app.vue`

- Added `starting_page` setting in `config.json` and code in `route.js` to re-route '/' to selected start page.

  - If `starting_page` not included in `config.json` then defaults to `home.vue`.

This commit also includes an *alternative* way to implement the default start page — a call to `$f7router.navigate()` can be included in the
`mounted()` method of `home.vue` to re-direct. Included this as an example but my suggested way to do it is in `routes.js` as that's where
I'd naturally look for default routes...

A new config file needs to be added to support these changes with the following structure:

```
{
  "apiKey" : "<supersecretcode>",
  "apiEndpoint" : "https://api.example.com",
  "apiSandboxEndpoint" : "https://api.example.com",
  "starting_page" : "<start_page>"
}
```
where `<start_page>` is a string of the desired start page. Not included as `config*` currently included in .gitignore (for obvious reasons).

Signed-off-by: Rod Manning <rod.manning@taslytic.com>